### PR TITLE
Support python3

### DIFF
--- a/Get.py
+++ b/Get.py
@@ -1,3 +1,13 @@
+# This code reads from the Thingful node, gets  list of all Sensors
+# The code then reads through the list of sensors and counts the number with a location of
+# zero (at the moment assumes if x=0 y=0)
+# Then displays percentage that are zero locations
+# Documentation for GROW node
+# https://growobservatory.github.io/ThingfulNode/#tag/Locations
+#
+#
+#
+
 import requests, json, sys
 # secret contains API Key.  Not in Github repo !
 # expects  AuthCode='API Key obtained from Thingful'

--- a/Get.py
+++ b/Get.py
@@ -1,30 +1,24 @@
-# This code reads from the Thingful node, gets  list of all Sensors
-# The code then reads through the list of sensors and counts the number with a location of
-# zero (at the moment assumes if x=0 y=0)
-# Then displays percentage that are zero locations
-# Documentation for GROW node
-# https://growobservatory.github.io/ThingfulNode/#tag/Locations
-#
-#
-#
-
-import httplib,json
+import requests, json, sys
 # secret contains API Key.  Not in Github repo !
 # expects  AuthCode='API Key obtained from Thingful'
 # see
 # https://growobservatory.github.io/ThingfulNode/#
 # how to get a Key
-from Secret import *
-c = httplib.HTTPSConnection("grow.thingful.net")
+from Secret import AuthCode
 
-headers = {'Authorization': 'Bearer %s' % AuthCode}
-params = json.dumps({'DataSourceCodes': ['Thingful.Connectors.GROWSensors'] })
+url = "https://grow.thingful.net/api/entity/locations/get"
+headers = {"Authorization": "Bearer {0}".format(AuthCode)}
+payload = json.dumps({'DataSourceCodes': ['Thingful.Connectors.GROWSensors'] })
 
-c.request("POST", "/api/entity/locations/get", params, headers)
+response = requests.post(url, headers=headers, data=payload)
 
-response = c.getresponse()
-#print response.status, response.reason
-jResp=json.loads(response.read())
+jResp = response.json()
+
+# exit if status code is not ok
+if response.status_code != 200:
+  print("Unexpected response: {0}. Status: {1}. Message: {2}".format(response.reason, response.status, jResp['Exception']['Message']))
+  sys.exit()
+
 #print json.dumps(jResp,indent=4,sort_keys=True)
 #for key in jResp.items():
 #    print key
@@ -33,22 +27,25 @@ jResp=json.loads(response.read())
 
 Locations = jResp["Locations"]
 numSensor=len(Locations)
-print "Number of Sensors : %d" % numSensor
+print("Number of Sensors : {0}".format(numSensor))
+
 xCount=0
 yCount=0
 Count=0
 for thing in Locations:
-#        print thing
-        th=Locations[thing]
-        x=th["X"]
-        y=th["Y"]
-#        print json.dumps(th,indent=4,sort_keys=True)
-#        print x,y
-        if (x==0):
-           xCount+=1
-        if (y==0):
-           yCount+=1
-        if ((x==0) and (y==0)):
-           Count+=1
+  # print thing
+  th=Locations[thing]
+  x=th["X"]
+  y=th["Y"]
+
+  # print json.dumps(th,indent=4,sort_keys=True)
+  # print x,y
+  if (x==0):
+      xCount+=1
+  if (y==0):
+      yCount+=1
+  if ((x==0) and (y==0)):
+      Count+=1
+
 Percent= float(xCount)/float(numSensor)*100
-print "Blanks Total %d  x-coord %d y-coord %d,  Percentage Blank %2.0f%%" % (Count,xCount, yCount, Percent)
+print("Blanks Total {0} | x-coord {1} | y-coord {2} | Percentage Blank {3}".format(Count, xCount, yCount, Percent))

--- a/README.md
+++ b/README.md
@@ -6,8 +6,42 @@ zero
 
 Then displays percentage that are zero locations
 
+## Dependencies 
+- python2 or python3
+- [pip](https://pip.pypa.io/en/stable/installing/) - the recommended tool for installing Python packages.
+- [requests](http://docs.python-requests.org/en/master/) - http requests library
 
-Documentation for GROW node
+## Run the script
+This script requires python.
+To verify that python is already installed on your machine run 
+```
+python --version
+```
+If the command above returns something like `Python 2.7.10` then python is already installed. If not you can download it [here](https://www.python.org/downloads/).
+Further instructions can be found on the [official documentation](http://docs.python-guide.org/en/latest/starting/installation/)
+
+The next step is to install the required dependencies. We recommend using `pip`.
+Verify that pip is installed by running 
+```
+pip --version
+```
+If pip is not installed follow the step described on the [official documentation](https://packaging.python.org/tutorials/installing-packages/#ensure-you-can-run-pip-from-the-command-line) 
+
+You can install dependencies with :
+```
+pip install -r requirements.txt
+```
+Alternatively you can install individual packages running:
+```
+pip install <package-name>
+```
+
+Finally run the script with
+```
+python Get.py
+```
+
+## Documentation for GROW node
 https://growobservatory.github.io/ThingfulNode/#tag/Locations
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2018.4.16
+chardet==3.0.4
+idna==2.7
+requests==2.19.0
+urllib3==1.23


### PR DESCRIPTION
This PR replaces the `httplib` with `requests` to allow support for python 3 users.

It also add some basic documentation about how to install dependencies and run the script.