### PR TITLE
Key as argument

### DIFF
--- a/Get.py
+++ b/Get.py
@@ -11,7 +11,7 @@ import requests
 import json
 import sys
 
-# ensure the has been passed as argument
+# ensure the key has been passed as argument
 try:
     api_key = sys.argv[1]
 except:

--- a/Get.py
+++ b/Get.py
@@ -15,7 +15,7 @@ import sys
 try:
     api_key = sys.argv[1]
 except:
-    sys.exit("The API key must be passed passed as argument when executing the script. Please run 'python Get.py <your-api-key>'.")
+    sys.exit("The API key must be passed as argument when executing the script. Please run 'python Get.py <your-api-key>'.")
 
 url = "https://grow.thingful.net/api/entity/locations/get"
 headers = {"Authorization": "Bearer {0}".format(api_key)}

--- a/Get.py
+++ b/Get.py
@@ -1,23 +1,24 @@
-# This code reads from the Thingful node, gets  list of all Sensors
-# The code then reads through the list of sensors and counts the number with a location of
-# zero (at the moment assumes if x=0 y=0)
-# Then displays percentage that are zero locations
-# Documentation for GROW node
-# https://growobservatory.github.io/ThingfulNode/#tag/Locations
-#
-#
-#
+"""
+This code reads from the Thingful node and gets a list of all Sensors.
+The code then reads through the list of sensors and counts the number 
+with a location of zero (at the moment assumes if x=0 y=0). Then displays 
+percentage that are zero locations. 
+Documentation for the GROW node is available at: 
+https://growobservatory.github.io/ThingfulNode/#tag/Locations
+"""
 
-import requests, json, sys
-# secret contains API Key.  Not in Github repo !
-# expects  AuthCode='API Key obtained from Thingful'
-# see
-# https://growobservatory.github.io/ThingfulNode/#
-# how to get a Key
-from Secret import AuthCode
+import requests
+import json
+import sys
+
+# ensure the has been passed as argument
+try:
+    api_key = sys.argv[1]
+except:
+    sys.exit("The API key must be passed passed as argument when executing the script. Please run 'python Get.py <your-api-key>'.")
 
 url = "https://grow.thingful.net/api/entity/locations/get"
-headers = {"Authorization": "Bearer {0}".format(AuthCode)}
+headers = {"Authorization": "Bearer {0}".format(api_key)}
 payload = json.dumps({'DataSourceCodes': ['Thingful.Connectors.GROWSensors'] })
 
 response = requests.post(url, headers=headers, data=payload)
@@ -26,8 +27,7 @@ jResp = response.json()
 
 # exit if status code is not ok
 if response.status_code != 200:
-  print("Unexpected response: {0}. Status: {1}. Message: {2}".format(response.reason, response.status, jResp['Exception']['Message']))
-  sys.exit()
+    sys.exit("Unexpected response: {0}. Status: {1}. Message: {2}".format(response.reason, response.status_code, jResp['Exception']['Message']))
 
 #print json.dumps(jResp,indent=4,sort_keys=True)
 #for key in jResp.items():
@@ -43,19 +43,19 @@ xCount=0
 yCount=0
 Count=0
 for thing in Locations:
-  # print thing
-  th=Locations[thing]
-  x=th["X"]
-  y=th["Y"]
+    # print thing
+    th=Locations[thing]
+    x=th["X"]
+    y=th["Y"]
 
-  # print json.dumps(th,indent=4,sort_keys=True)
-  # print x,y
-  if (x==0):
-      xCount+=1
-  if (y==0):
-      yCount+=1
-  if ((x==0) and (y==0)):
-      Count+=1
+    # print json.dumps(th,indent=4,sort_keys=True)
+    # print x,y
+    if (x==0):
+        xCount+=1
+    if (y==0):
+        yCount+=1
+    if ((x==0) and (y==0)):
+        Count+=1
 
 Percent= float(xCount)/float(numSensor)*100
 print("Blanks Total {0} | x-coord {1} | y-coord {2} | Percentage Blank {3}".format(Count, xCount, yCount, Percent))

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python Get.py <your-api-key>
 ## Obtaining API Keys
 Users must be authenticated using their [API key](https://en.wikipedia.org/wiki/Application_programming_interface_key) when interacting with the GROW Node.
 In order to obtain a key please contact
-- dev@thingful.com 
+- dev@thingful.net 
 
 ## Documentation for GROW node
 https://growobservatory.github.io/ThingfulNode/#tag/Locations

--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ pip install <package-name>
 
 Finally run the script with
 ```
-python Get.py
+python Get.py <your-api-key>
 ```
+
+## Obtaining API Keys
+Users must be authenticated using their [API key](https://en.wikipedia.org/wiki/Application_programming_interface_key) when interacting with the GROW Node.
+In order to obtain a key please contact
+- dev@thingful.com 
 
 ## Documentation for GROW node
 https://growobservatory.github.io/ThingfulNode/#tag/Locations


### PR DESCRIPTION
This PR allows users to pass their API key as script argument.
If the key is not set the script will exit and raise an error prompting the user to set her key.

The readme file has also been updated with instructions about how to obtain a new key.